### PR TITLE
Fix reference to ruby/setup-ruby

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
         run: echo "::set-output name=RUBY_VERSION::$(cat .ruby-version)"
 
       - name: Install Ruby
-        uses: ruby/setup-ruby/@v1
+        uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ steps.ruby_version.outputs.RUBY_VERSION }}
 


### PR DESCRIPTION
I noticed it from https://github.com/ruby/setup-ruby/network/dependents?package_id=UGFja2FnZS0yOTY2NDM1NzI0